### PR TITLE
Upgraded gradle wrapper to support java 20

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### :pushpin: References
* **Solved issues:** None
* **Related pull requests:** None
* **Documentation:** https://docs.gradle.org/current/userguide/compatibility.html

### :tophat: Goal
Version of the wrapper does not support java 20. This causes debugging to not work

### :memo: Implementation
Upgraded gradle wrapper to 8.3. Supported java versions for each gradle version are in the link in the documentation section

### :memo: Additional notes
None

### :boom: Testing
I use intellij for developing
- [ ] **Use case 1:** Check that running the tests on debug mode works.
- [ ] **Use case 2:** Check that running the tests without debugging works.
  
### :red_circle: Deployment
Not needed